### PR TITLE
Add red and orange accents, remove grayscale filter for bookmarks

### DIFF
--- a/main.css
+++ b/main.css
@@ -7,6 +7,8 @@
 	--muted: #bac8c9;
 	--cyan: #00f2ff;
 	--purple: #b600f8;
+	--red: #ff1744;
+	--orange: #ff7a00;
 	--rail: rgba(255, 255, 255, 0.22);
 	--radius: 0.25rem;
 	--gap: 1.5rem;
@@ -147,6 +149,14 @@ body::before {
 	--accent: var(--purple);
 }
 
+.bookmark-grid .bookmark-group:nth-child(2) {
+	--accent: var(--red);
+}
+
+.bookmark-grid .bookmark-group:nth-child(4) {
+	--accent: var(--orange);
+}
+
 .group-heading {
 	display: flex;
 	align-items: center;
@@ -169,10 +179,6 @@ body::before {
 	font-size: 1.45rem;
 	line-height: 1;
 	font-variation-settings: "FILL" 0, "wght" 500, "GRAD" 0, "opsz" 24;
-}
-
-.bookmark-group:not(.bookmark-group--cyan):not(.bookmark-group--purple) .group-heading {
-	color: var(--muted);
 }
 
 ul {
@@ -209,14 +215,12 @@ ul {
 	padding: 0.1rem;
 	border-radius: 0.16rem;
 	background: rgba(255, 255, 255, 0.09);
-	filter: grayscale(1) brightness(0.72);
-	transition: filter 150ms ease, background-color 150ms ease;
+	transition: background-color 150ms ease;
 }
 
 .bookmark-link:hover img,
 .bookmark-link:focus-visible img {
 	background: rgba(255, 255, 255, 0.14);
-	filter: none;
 }
 
 .bookmark-link span {


### PR DESCRIPTION
This pull request updates the `main.css` file to add new accent colors and improve the visual distinction between bookmark groups. The main focus is on introducing red and orange accent colors for specific bookmark groups and simplifying some styling rules.

**Theme: New Accent Colors and Group Styling**
* Added `--red` and `--orange` CSS variables for use as accent colors.
* Applied the new `--red` and `--orange` accent colors to the second and fourth bookmark groups, respectively, using `.bookmark-grid .bookmark-group:nth-child(2)` and `.bookmark-grid .bookmark-group:nth-child(4)`.

**Theme: Style Simplification and Cleanup**
* Removed a rule that set muted color for group headings of certain bookmark groups, allowing accent colors to show instead.
* Simplified the `ul` and `.bookmark-link` styles by removing grayscale and brightness filters and their transitions, resulting in a cleaner appearance for bookmark lists and links.Introduce --red and --orange CSS variables and assign them as accents for the 2nd and 4th bookmark groups. Remove the fallback muted color rule for group headings and eliminate the grayscale filter on bookmark items (and its hover reset), simplifying the transition to only affect background-color. These changes enable additional accent colors and remove desaturation behavior for clearer, more colorful bookmark items.